### PR TITLE
fix(tion): don't require response while notification subscription

### DIFF
--- a/tion_btle/tion.py
+++ b/tion_btle/tion.py
@@ -368,7 +368,7 @@ class tion(TionDummy):
         notify_handle = self.notify.getHandle() + 1
 
         _LOGGER.debug("Will write %s to %s handle", data, notify_handle)
-        result = self._btle.writeCharacteristic(notify_handle, data, withResponse=True)
+        result = self._btle.writeCharacteristic(notify_handle, data, withResponse=False)
         _LOGGER.debug("Result is %s", result)
 
     def _enable_notifications(self):


### PR DESCRIPTION
We should not requesting response while subscription to notification and unsubscription.
If response requested, than we got "Unexpected response" error from bluepy.

Fix #25