### PR TITLE
fix: pop first byte of request while splitting

### DIFF
--- a/tion_btle/light_family.py
+++ b/tion_btle/light_family.py
@@ -105,7 +105,7 @@ class TionLiteFamily(Tion):
             for j in range(0, len(lst), n):
                 yield lst[j:j + n]
 
-        request.pop()
+        request.pop(0)
 
         if len(request) < 20:
             request.insert(0, self.SINGLE_PACKET_ID)


### PR DESCRIPTION
We should pass position to `pop()` to remove first element of array.

Fix [HA-tion/#92](https://github.com/TionAPI/HA-tion/issues/92)